### PR TITLE
Fix: Cannot read property 'push' of undefined in fromObjects

### DIFF
--- a/src/jquery.csv.js
+++ b/src/jquery.csv.js
@@ -944,7 +944,7 @@ RegExp.escape = function (s) {
         props = propsManual;
       }
 
-      var o, p, line, output, propName;
+      var o, p, line, output = [], propName;
       if (config.headers) {
         output.push(props);
       }


### PR DESCRIPTION
If this PR applies to an existing spec, link to it and delete the rest.

## Checklist

- [ ] Is this API breaking? 
- [ ] Is this tested? 
- [ ] Is Documentation required?

*Note: Don't worry about leaving these unchecked. These exist to quickly identify common requirements.*

## Description

Cannot read property 'push' of undefined in fromObjects

## References
