### PR TITLE
Accept any character as delimiter/separator

### DIFF
--- a/src/jquery.csv.js
+++ b/src/jquery.csv.js
@@ -861,8 +861,9 @@ RegExp.escape = function (s) {
           }
 
           var escMatcher = '\n|\r|S|D';
-          escMatcher = escMatcher.replace('S', config.separator);
-          escMatcher = escMatcher.replace('D', config.delimiter);
+          var replacer = /[-[\]{}()*+?.,\\^$|#\s]/g;
+          escMatcher = escMatcher.replace('S', config.separator.replace(replacer, '\\$&'));
+          escMatcher = escMatcher.replace('D', config.delimiter.replace(replacer, '\\$&'));
 
           if (strValue.search(escMatcher) > -1) {
             strValue = config.delimiter + strValue + config.delimiter;


### PR DESCRIPTION
Currently, RegExp special characters are problematic (`(` or `*`).

This PR escapes RegExp special characters so they can be used as delimiters and/or separators.

When using `(` as a separator, this RegExp will be generated: `\n|\r|(|"` which is an invalid RegExp, throwing an error. With this PR, when using a parenthesis, this RegExp will be generated: `\n|\r|\(|"` (Escaping the parenthesis) which is valid.