### PR TITLE
Fix how you import the npm module

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ npm i jquery-csv
 Then import it as a CommonJS module.
 
 ```javascript
-var csv = require('./jquery.csv.js');
+var csv = require('jquery-csv');
 ```
 
 ## Usage


### PR DESCRIPTION
If this PR applies to an existing spec, link to it and delete the rest.

## Checklist

- [ ] Is this API breaking?
- [ ] Is this tested?
- [ ] Is Documentation required?

*Note: Don't worry about leaving these unchecked. These exist to quickly identify common requirements.*

## Description

The current [documentation contains an error](https://stackoverflow.com/a/65053210/6126373) on how you import the npm module. This PR fixes that.
